### PR TITLE
Fix bugs and add cn-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@
 需要条件：<br/>
 下载该repo文件夹，不要修改任何文件名<br/>
 安装python包[Twisted](https://github.com/twisted/twisted)。<br/>
-最新版本的twisted可能需要update一下你的pyOpenSSL才能使用。也可以选择装个旧版本。
+最新版本的twisted需要更新pyOpenSSL才能使用。也可以选择装个旧版本。
 
 在每次打开网易云音乐之前：<br/>
 进入文件夹，双击NeteaseMusicHelper即可。等待提示信息成功之后可以关掉它，然后一片清净，开心听歌，不用善后。
 
 ### 测试环境
 
-macOS 10.12，NeteaseMusic Version 1.5.6，年费会员。未测试任何其他情况，欢迎测试报bug谢谢。
+macOS 10.12，NeteaseMusic Version 1.5.6，python 2.7.10，年费会员。未测试任何其他情况，欢迎测试报bug谢谢。
 
 ### 实现细节
 
 见下方Inplementation details。这里只说两点：<br/>
 1. 歌单中所有歌曲都不再显示灰色，但点击无版权歌曲（大陆也不能播放）后仍然会提示“播放失败”。暂无解决思路，且不想涉及侵权。<br/>
-2. 目前对音频文件URL请求（也只有这一请求）走的是窝的国内阿里云。显然带宽很小，有时有一点延迟。TODO：换成自动使用 http://cn-proxy.com/ 的免费代理。
+2. 目前对音频文件URL请求（也只有这一请求）采用的是cn-proxy的最优代理，缺省代理为原作者的阿里云地址。
 
 _________________
 
@@ -78,4 +78,3 @@ Methods that I tried:
 Part 2. Intercept, modify and redirect requests.
 
 See `NeteaseMusicProxy.py` (deployed as local proxy) and `AudioRequestProxy.py` (deployed as domestic proxy).<br/>
-TODO: Automatically use free domestic proxies in http://cn-proxy.com/.


### PR DESCRIPTION
Hi, maybe limited to my network environment, sometimes the POST request you intercept, especially playlists with more than 100 songs, might be cut into multiple function calls, so that gzip can't decode easily, which causes error.
I added function to cache the previous buffer that can't be decoded.

Also I wrote a function to get the first proxy on cn-proxy.